### PR TITLE
Support for partial indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,24 @@ cat <<EOF > /etc/freetds/locales.conf
     date format = %F %T.%z
 EOF
 ```
+
+# Testing
+
+This project provides a full docker environment for running regression tests. An
+MSSQL instance comes with an [AdventureWorks database][adventureworks] that must
+be extended by several objects:
+
+[adventureworks]: https://hub.docker.com/r/chriseaton/adventureworks
+
+```sh
+# start up containers
+make docker-up
+
+# create complementary objects
+docker exec -it mssql_migrator-mssql_db-1 /opt/mssql-tools/bin/sqlcmd \
+  -S localhost -d AdventureWorks -U sa -P "Passw0rd" \
+  -i /mnt/mssql_mktest.sql
+
+# regression testing
+make docker-install installcheck
+```

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,6 +8,8 @@ services:
       SA_PASSWORD: Passw0rd
     networks:
       - common
+    volumes:
+      - ..:/mnt
     ports:
       - "1433:1433"
   

--- a/expected/migrate.out
+++ b/expected/migrate.out
@@ -84,3 +84,10 @@ SELECT db_migrate_finish();
                  0
 (1 row)
 
+/* check some results */
+SELECT indexdef FROM pg_indexes WHERE indexname = 'IX_Person_rowguid_filtered';
+                                                     indexdef                                                      
+-------------------------------------------------------------------------------------------------------------------
+ CREATE INDEX "IX_Person_rowguid_filtered" ON "Person"."Person" USING btree (rowguid) WHERE ("EmailPromotion" = 1)
+(1 row)
+

--- a/mssql_migrator--0.2.1.sql
+++ b/mssql_migrator--0.2.1.sql
@@ -267,10 +267,12 @@ DECLARE
             schema        text    NOT NULL,
             table_name    text    NOT NULL,
             index_name    text    NOT NULL,
-            uniqueness    boolean NOT NULL
+            uniqueness    boolean NOT NULL,
+            where_clause  text
         ) SERVER %2$I OPTIONS (query
             E'SELECT s.name AS "schema", t.name AS table_name, '
-                    'i.name AS index_name, i.is_unique AS uniqueness '
+                    'i.name AS index_name, i.is_unique AS uniqueness, '
+                    'i.filter_definition AS where_clause '
              'FROM sys.indexes i '
              'INNER JOIN sys.tables t ON i.object_id = t.object_id '
              'INNER JOIN sys.schemas s ON t.schema_id = s.schema_id '

--- a/mssql_migrator.control
+++ b/mssql_migrator.control
@@ -1,5 +1,5 @@
 comment = 'Tools to migrate SQL Server databases to PostgreSQL'
-default_version = '0.2.0'
+default_version = '0.2.1'
 requires = 'tds_fdw, db_migrator'
 superuser = false
 relocatable = true

--- a/mssql_mktest.sql
+++ b/mssql_mktest.sql
@@ -1,3 +1,16 @@
+SET QUOTED_IDENTIFIER ON;
+
+-- Indexes
+
+IF EXISTS (SELECT * FROM sys.indexes WHERE name = 'IX_Person_rowguid_filtered')
+    DROP INDEX IX_Person_rowguid_filtered ON Person.Person;
+GO
+
+CREATE NONCLUSTERED INDEX IX_Person_rowguid_filtered ON Person.Person(rowguid) WHERE EmailPromotion = 1;
+GO
+
+-- Partitioning
+
 IF NOT EXISTS (SELECT name FROM sys.schemas WHERE name = 'Partitions')
 	EXEC('CREATE SCHEMA [Partitions]');
 GO

--- a/sql/migrate.sql
+++ b/sql/migrate.sql
@@ -68,3 +68,6 @@ FROM pgsql_stage.migrate_log
 ORDER BY log_time \gx
 
 SELECT db_migrate_finish();
+
+/* check some results */
+SELECT indexdef FROM pg_indexes WHERE indexname = 'IX_Person_rowguid_filtered';


### PR DESCRIPTION
Extends "indexes" table with new "where_clause" column to handles filtered indexes from MSSQL.

* Requires db_migrator 1.1.0.
* Add new "testing" chapter to README.md